### PR TITLE
Fix luaL_typerror missing for newer lua versions

### DIFF
--- a/native_objects/gen_lua.lua
+++ b/native_objects/gen_lua.lua
@@ -2508,7 +2508,7 @@ static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
 
 #endif
 
-#if LUA_VERSION_NUM == 502
+#if LUA_VERSION_NUM >= 502
 
 #define lua_load_no_mode(L, reader, data, source) \
 	lua_load(L, reader, data, source, NULL)


### PR DESCRIPTION
This fixes errors when generating code for lua 5.3.